### PR TITLE
feat(nano-banana-pro): add multi-image support (up to 14 inputs)

### DIFF
--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana-pro
-description: Generate and edit images using Google's Nano Banana Pro (Gemini 3 Pro Image) API. Use when the user asks to generate, create, edit, modify, change, alter, or update images. Also use when user references an existing image file and asks to modify it in any way (e.g., "modify this image", "change the background", "replace X with Y"). Supports both text-to-image generation and image-to-image editing with configurable resolution (1K default, 2K, or 4K for high resolution). DO NOT read the image file first - use this skill directly with the --input-image parameter.
+description: Generate and edit images using Google's Nano Banana Pro (Gemini 3 Pro Image) API. Use when the user asks to generate, create, edit, modify, change, alter, or update images. Also use when user references an existing image file and asks to modify it in any way (e.g., "modify this image", "change the background", "replace X with Y"). Supports both text-to-image generation and image-to-image editing with configurable resolution (1K default, 2K, or 4K for high resolution). Supports multiple input images (up to 14) for combining, compositing, or referencing elements from several sources. DO NOT read the image file first - use this skill directly with the --input-image parameter.
 ---
 
 # Nano Banana Pro Image Generation & Editing
@@ -19,6 +19,11 @@ uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "your
 **Edit existing image:**
 ```bash
 uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "editing instructions" --filename "output-name.png" --input-image "path/to/input.png" [--resolution 1K|2K|4K] [--api-key KEY]
+```
+
+**Combine/edit multiple images (up to 14):**
+```bash
+uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "combine these images into a scene" --filename "output-name.png" --input-image "image1.png" "image2.png" "image3.png" [--resolution 1K|2K|4K] [--api-key KEY]
 ```
 
 **Important:** Always run from the user's current working directory so images are saved where the user is working, not in the skill directory.
@@ -66,9 +71,23 @@ Examples:
 
 When the user wants to modify an existing image:
 1. Check if they provide an image path or reference an image in the current directory
-2. Use `--input-image` parameter with the path to the image
+2. Use `--input-image` parameter with the path(s) to the image(s)
 3. The prompt should contain editing instructions (e.g., "make the sky more dramatic", "remove the person", "change to cartoon style")
 4. Common editing tasks: add/remove elements, change style, adjust colors, blur background, etc.
+
+## Multiple Image Input
+
+The Gemini 3 Pro Image API supports up to **14 reference images** per request:
+- Up to 6 high-fidelity object images
+- Up to 5 character-consistency images
+
+Pass multiple paths to `--input-image` separated by spaces. Use cases include:
+- **Compositing**: combine a product from one image with a background from another
+- **Style transfer**: apply the style of one image to the content of another
+- **Character consistency**: provide multiple reference photos of a person to maintain likeness
+- **Group scenes**: provide individual portraits to compose a group photo
+
+When referencing specific images in the prompt, label them (e.g., "Take the dress from the first image and place it on the person from the second image").
 
 ## Prompt Handling
 
@@ -94,4 +113,9 @@ uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "A se
 **Edit existing image:**
 ```bash
 uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "make the sky more dramatic with storm clouds" --filename "2025-11-23-14-25-30-dramatic-sky.png" --input-image "original-photo.jpg" --resolution 2K
+```
+
+**Combine multiple images:**
+```bash
+uv run ~/.claude/skills/nano-banana-pro/scripts/generate_image.py --prompt "Take the dress from the first image and let the woman from the second image wear it. Professional e-commerce photo." --filename "2025-11-23-14-30-00-fashion-composite.png" --input-image "dress.png" "model.png" --resolution 2K
 ```

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -10,7 +10,8 @@
 Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
 
 Usage:
-    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    uv run generate_image.py --prompt "description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    uv run generate_image.py --prompt "editing instructions" --filename "output.png" --input-image img1.png [img2.png ...] [--resolution 1K|2K|4K]
 """
 
 import argparse
@@ -42,7 +43,8 @@ def main():
     )
     parser.add_argument(
         "--input-image", "-i",
-        help="Optional input image path for editing/modification"
+        nargs="+",
+        help="Optional input image path(s) for editing/modification (up to 14)"
     )
     parser.add_argument(
         "--resolution", "-r",
@@ -78,34 +80,40 @@ def main():
     output_path = Path(args.filename)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Load input image if provided
-    input_image = None
+    # Load input images if provided
+    input_images: list = []
     output_resolution = args.resolution
     if args.input_image:
-        try:
-            input_image = PILImage.open(args.input_image)
-            print(f"Loaded input image: {args.input_image}")
-
-            # Auto-detect resolution if not explicitly set by user
-            if args.resolution == "1K":  # Default value
-                # Map input image size to resolution
-                width, height = input_image.size
-                max_dim = max(width, height)
-                if max_dim >= 3000:
-                    output_resolution = "4K"
-                elif max_dim >= 1500:
-                    output_resolution = "2K"
-                else:
-                    output_resolution = "1K"
-                print(f"Auto-detected resolution: {output_resolution} (from input {width}x{height})")
-        except Exception as e:
-            print(f"Error loading input image: {e}", file=sys.stderr)
+        if len(args.input_image) > 14:
+            print("Error: Maximum 14 input images allowed (Gemini API limit).", file=sys.stderr)
             sys.exit(1)
 
-    # Build contents (image first if editing, prompt only if generating)
-    if input_image:
-        contents = [input_image, args.prompt]
-        print(f"Editing image with resolution {output_resolution}...")
+        for img_path in args.input_image:
+            try:
+                img = PILImage.open(img_path)
+                input_images.append(img)
+                print(f"Loaded input image: {img_path}")
+            except Exception as e:
+                print(f"Error loading input image '{img_path}': {e}", file=sys.stderr)
+                sys.exit(1)
+
+        # Auto-detect resolution from the largest input image
+        if args.resolution == "1K":
+            max_dim = max(max(img.size) for img in input_images)
+            if max_dim >= 3000:
+                output_resolution = "4K"
+            elif max_dim >= 1500:
+                output_resolution = "2K"
+            else:
+                output_resolution = "1K"
+            sample_w, sample_h = input_images[0].size
+            print(f"Auto-detected resolution: {output_resolution} (from largest input, first image {sample_w}x{sample_h})")
+
+    # Build contents (images first if editing, prompt only if generating)
+    if input_images:
+        contents = [*input_images, args.prompt]
+        label = "image" if len(input_images) == 1 else f"{len(input_images)} images"
+        print(f"Editing {label} with resolution {output_resolution}...")
     else:
         contents = args.prompt
         print(f"Generating image with resolution {output_resolution}...")


### PR DESCRIPTION
## Summary

- **`--input-image` now accepts multiple paths** via `nargs="+"` — single-image usage is unchanged
- Validates the 14-image API limit with a clear error message
- Auto-resolution detection uses the largest dimension across all inputs
- Builds `contents = [*images, prompt]` matching the API's recommended ordering

## SKILL.md updates

- Added multi-image usage example and "Multiple Image Input" section
- Documented use cases: compositing, style transfer, character consistency, group scenes
- Updated description frontmatter to mention multi-image support

## Test plan

- [ ] Single image editing still works: `--input-image "photo.png"`
- [ ] Multiple images work: `--input-image "a.png" "b.png"`
- [ ] Error on >14 images
- [ ] Auto-resolution picks from the largest input image