### PR TITLE
feat(youtube-transcript): add --title-only flag via YouTube oEmbed API

### DIFF
--- a/skills/youtube-transcript/SKILL.md
+++ b/skills/youtube-transcript/SKILL.md
@@ -21,10 +21,17 @@ With timestamps:
 uv run scripts/get_transcript.py "VIDEO_URL_OR_ID" --timestamps
 ```
 
+Title only (useful for naming output files):
+
+```bash
+uv run scripts/get_transcript.py "VIDEO_URL_OR_ID" --title-only
+```
+
 ## Defaults
 
 - **Without timestamps** (default): Plain text, one line per caption segment
 - **With timestamps**: `[MM:SS] text` format (or `[HH:MM:SS]` for longer videos)
+- **Title only**: Fetches the video title via YouTube's oEmbed API (no auth required) and prints it to stdout
 
 ## Supported URL Formats
 

--- a/skills/youtube-transcript/scripts/get_transcript.py
+++ b/skills/youtube-transcript/scripts/get_transcript.py
@@ -7,12 +7,15 @@
 Extract transcript from a YouTube video.
 
 Usage:
-    uv run scripts/get_transcript.py <video_id_or_url> [--timestamps]
+    uv run scripts/get_transcript.py <video_id_or_url> [--timestamps] [--title-only]
 """
 
 import sys
 import re
+import json
 import argparse
+import urllib.parse
+import urllib.request
 from youtube_transcript_api import YouTubeTranscriptApi
 
 
@@ -29,6 +32,18 @@ def extract_video_id(url_or_id: str) -> str:
     raise ValueError(f"Could not extract video ID from: {url_or_id}")
 
 
+def get_title(video_id: str) -> str:
+    """Fetch the video title via YouTube's oEmbed API (no auth required)."""
+    video_url = urllib.parse.quote(f"https://www.youtube.com/watch?v={video_id}")
+    oembed_url = f"https://www.youtube.com/oembed?url={video_url}&format=json"
+    try:
+        with urllib.request.urlopen(oembed_url, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("title", "").strip()
+    except Exception:
+        return ""
+
+
 def format_timestamp(seconds: float) -> str:
     """Convert seconds to HH:MM:SS or MM:SS format."""
     hours = int(seconds // 3600)
@@ -43,24 +58,29 @@ def get_transcript(video_id: str, with_timestamps: bool = False) -> str:
     """Fetch and format transcript for a YouTube video."""
     api = YouTubeTranscriptApi()
     transcript = api.fetch(video_id)
-    
+
     if with_timestamps:
         lines = [f"[{format_timestamp(snippet.start)}] {snippet.text}" for snippet in transcript.snippets]
     else:
         lines = [snippet.text for snippet in transcript.snippets]
-    
+
     return '\n'.join(lines)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Get YouTube video transcript')
     parser.add_argument('video', help='YouTube video URL or video ID')
-    parser.add_argument('--timestamps', '-t', action='store_true', 
+    parser.add_argument('--timestamps', '-t', action='store_true',
                         help='Include timestamps in output')
+    parser.add_argument('--title-only', action='store_true',
+                        help='Print only the video title and exit')
     args = parser.parse_args()
-    
+
     try:
         video_id = extract_video_id(args.video)
+        if args.title_only:
+            print(get_title(video_id))
+            return
         transcript = get_transcript(video_id, with_timestamps=args.timestamps)
         print(transcript)
     except Exception as e:


### PR DESCRIPTION
## Problem

The skill had no way to retrieve a video's title — only the transcript. Agents that want to name output files meaningfully had to prompt the user for the title or scrape the YouTube page HTML (fragile, often blocked).

## Solution

Add a `--title-only` flag to `get_transcript.py` that queries YouTube's public oEmbed endpoint (`youtube.com/oembed?url=...&format=json`). This endpoint:

- Requires no API key or authentication
- Returns JSON including the video title
- Has no extra dependencies (uses stdlib `urllib` only)

## Changes

- `scripts/get_transcript.py` — added `get_title()` function and `--title-only` argparse flag
- `SKILL.md` — documented the new flag

## Usage

```bash
uv run scripts/get_transcript.py "https://www.youtube.com/watch?v=VIDEO_ID" --title-only
# → How to introduce yourself—and get hired | Rebecca Okamoto | TEDxNorthwesternU
```

## Test plan

- [ ] `--title-only` prints the correct title for a public video
- [ ] `--title-only` exits 0 and prints empty string for an unlisted/private video (oEmbed returns 404, caught by the try/except)
- [ ] Existing `--timestamps` and plain transcript behaviour unchanged